### PR TITLE
update GA workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,11 +12,6 @@ jobs:
         php: [8.3, 8.2, 8.1]
         laravel: [11.*, 10.*]
         dependency-version: [prefer-stable]
-        include:
-          - laravel: 11.*
-            testbench: 9.*
-          - laravel: 10.*
-            testbench: 8.*
         exclude:
           - laravel: 11.*
             php: 8.1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,10 +9,19 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.1]
+        php: [8.3, 8.2, 8.1]
+        laravel: [11.*, 10.*]
         dependency-version: [prefer-stable]
+        include:
+          - laravel: 11.*
+            testbench: 9.*
+          - laravel: 10.*
+            testbench: 8.*
+        exclude:
+          - laravel: 11.*
+            php: 8.1
 
-    name: Tests P${{ matrix.php }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}
+    name: Tests P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.os }} - ${{ matrix.dependency-version }}
 
     steps:
 
@@ -23,7 +32,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: ~/.composer/cache/files
-          key: dependencies-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
+          key: dependencies-${{ matrix.os }}-laravel-${{ matrix.laravel }}-php-${{ matrix.php }}-composer-${{ hashFiles('composer.json') }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -33,7 +42,9 @@ jobs:
           coverage: none
 
       - name: Install Composer dependencies
-        run: composer update --${{ matrix.dependency-version }} --no-interaction --prefer-dist
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
+          composer update --${{ matrix.dependency-version }} --no-interaction --prefer-dist
 
       - name: Run Tests
         run: composer test:unit


### PR DESCRIPTION
Test workflow has been updated to cover php 8.1, 8.2, 8.3 and laravel 10, 11
however the test workflow only verifies that this package able to install with the php and laravel versions, as there is no tests found
![image](https://github.com/alazzi-az/laraodoo-xmlrpc/assets/67364036/8e4afc45-6614-4bc1-9609-7ef195bc475e)
